### PR TITLE
Change chinese translation language

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -199,7 +199,7 @@ languages:
     weight: 2
     contentDir: "content/tr"
   zh-CN:
-    languageName: "大陆简体"
+    languageName: "简体中文"
     weight: 2
     contentDir: "content/zh-CN"
 


### PR DESCRIPTION
"mainland simplified" -> "simplified chinese"

mainland china is not the only country using simplified chinese,
many other countries use it too so it should not have "mainland" there